### PR TITLE
Update USB port detection for macOS Tahoe 26

### DIFF
--- a/USBMap.py
+++ b/USBMap.py
@@ -574,7 +574,7 @@ class USBMap:
                 for line in self.ioreg[i+1:]:
                     if line.replace("|","").strip() == "}":
                         break # We hit the end of that port
-                    elif '"port" = ' in line:
+                    elif '"port" = ' in line or '"usb-port-number" = ' in line:
                         obj["port"] = line.split("<")[1].split(">")[0]
                     elif '"UsbConnector" = ' in line:
                         try: obj["connector"] = int(line.split(" = ")[1].strip())


### PR DESCRIPTION
I need more time to figure out why USBMap isn't working with macOS Tahoe 26. I'll try to update it soon, along with USBToolBox if possible.